### PR TITLE
- make elements top-leading instead of centered

### DIFF
--- a/Sources/WaterfallGrid/WaterfallGrid.swift
+++ b/Sources/WaterfallGrid/WaterfallGrid.swift
@@ -56,7 +56,7 @@ public struct WaterfallGrid<Data, ID, Content>: View where Data : RandomAccessCo
                 }
             }
             .padding(style.padding)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(minWidth: 0, idealWidth: geometry.size.width, maxWidth: .infinity, minHeight: 0, idealHeight: geometry.size.height, maxHeight: .infinity, alignment: .topLeading)
             .animation(self.loaded ? self.style.animation : nil)
         }
     }


### PR DESCRIPTION
I want to allow elements to be top-left instead of centered if there is only one element. Is this the right approach? Should there be an style option for this?